### PR TITLE
Fix label-selector example

### DIFF
--- a/label-selectors/main.go
+++ b/label-selectors/main.go
@@ -15,7 +15,7 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-	sel.Add(*req)
+	sel = sel.Add(*req)
 	if sel.Matches(lbls) {
 		fmt.Printf("Selector %v matched label set %v\n", sel, lbls)
 	} else {


### PR DESCRIPTION
At present, the selector remains empty even after the `sel.Add(req)` call.

`fmt.Printf("%v", sel)` prints empty string.

This is because the mutated sel is not reveived and assigned to sel at the caller.

note: the signature of sel.Add function is `Add(r ...Requirement) Selector`

Signed-off-by: Nikhil Thomas <nikhilthomas1@gmail.com>