### PR TITLE
Implement CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         example_to_test: ${{fromJson(needs.prepare.outputs.dirs)}}
-        go_version: [1.17.x]
-        kubernetes_version: [1.17.17]
+        k8s_client_go_version: [v0.23.1, v0.24.7, v0.25.3]
         # kubernetes_version: [1.17.17, 1.18.20, 1.19.16, 1.20.15, 1.21.14, 1.22.15, 1.23.12, 1.24.6, 1.25.2]
+        kubernetes_version: [1.17.17]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version: 1.17.x
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.3.0
         with:
@@ -43,5 +43,6 @@ jobs:
       - name: Run tests for ${{matrix.example_to_test}}
         run: |
           cd ${{matrix.example_to_test}}
+          go mod edit -replace k8s.io/client-go=k8s.io/client-go@${{matrix.k8s_client_go_version}}
           go mod tidy
           go run main.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: test
+
+on:
+  push:
+    branches:
+    - '*'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: make-list
+        run: |
+          echo "::set-output name=dirs::$(ls -d */ | jq -R -s -c 'split("\n")[:-1]')"
+    outputs:
+      dirs: ${{steps.make-list.outputs.dirs}}
+  test:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        example_to_test: ${{fromJson(needs.prepare.outputs.dirs)}}
+        go_version: [1.17.x]
+        kubernetes_version: [1.17.17]
+        # kubernetes_version: [1.17.17, 1.18.20, 1.19.16, 1.20.15, 1.21.14, 1.22.15, 1.23.12, 1.24.6, 1.25.2]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go_version }}
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.3.0
+        with:
+          node_image: kindest/node:v${{ matrix.kubernetes_version }}
+      - name: Run tests for ${{matrix.example_to_test}}
+        run: |
+          cd ${{matrix.example_to_test}}
+          go mod tidy
+          go run main.go


### PR DESCRIPTION
Signed-off-by: Maria Kotlyarevskaya <mariia.kotliarevskaia@gmail.com>

Hey @iximiuz! I took an initiative to implement some POC of CI for this repository. 
The main issue with it is that some of the examples expect you pass extra options during the start or create something beforehand. 

The current implementation is very simple and works this way:
1. takes list of the directories in this repo, create a json valid list
2. run go mod tidy, go run main.go in each of this directories
3. it supports working with several go / kubernetes versions easily. (but we need to figure out how to set up it properly, because even now one of the examples requires go 1.18)

You can see it alive [here](https://github.com/Jasstkn/client-go-examples/actions/runs/3307361751).
Let me know what do you think :) 